### PR TITLE
Fix networking problem after restarting Windows node

### DIFF
--- a/windows-node/install/PrepareNode.ps1
+++ b/windows-node/install/PrepareNode.ps1
@@ -67,11 +67,16 @@ New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C
 $StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
 $global:KubeletArgs = $FileContent.Trim("KUBELET_KUBEADM_ARGS=`"")
 
-$netId = docker network ls -f name=host --format "{{ .ID }}"
+# Recreate network for pods
+Stop-Service docker
+nssm stop HNS
+rm C:\ProgramData\Microsoft\Windows\HNS\HNS.data
+nssm start HNS
+Start-Service docker
+docker network create -d nat host
 
-if ($netId.Length -lt 1) {
-    docker network create -d nat host
-}
+# May needs to restart network adapter
+Restart-NetAdapter -Name "Ethernet"
 
 $cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:1.3.0`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m"
 


### PR DESCRIPTION
Windows node will lose abilities to access K8s service network after restarting for some reason. It seems like flannel cannot using the older Docker network properly which named host.

This problem can be fixed by adding some commands to remove old HNS data and recreate docker network.