### PR TITLE
Recover PrepareNode.ps1 and create ReplaceKubeletScript.ps1

### DIFF
--- a/windows-node/install/PrepareNode.ps1
+++ b/windows-node/install/PrepareNode.ps1
@@ -67,16 +67,11 @@ New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C
 $StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
 $global:KubeletArgs = $FileContent.Trim("KUBELET_KUBEADM_ARGS=`"")
 
-# Recreate network for pods
-Stop-Service docker
-nssm stop HNS
-rm C:\ProgramData\Microsoft\Windows\HNS\HNS.data
-nssm start HNS
-Start-Service docker
-docker network create -d nat host
+$netId = docker network ls -f name=host --format "{{ .ID }}"
 
-# May needs to restart network adapter
-Restart-NetAdapter -Name "Ethernet"
+if ($netId.Length -lt 1) {
+    docker network create -d nat host
+}
 
 $cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:1.3.0`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m"
 

--- a/windows-node/install/ReplaceKubeletScript.ps1
+++ b/windows-node/install/ReplaceKubeletScript.ps1
@@ -1,0 +1,22 @@
+$global:KubernetesPath = "$env:SystemDrive\k"
+$global:StartKubeletScript = "$global:KubernetesPath\StartKubelet.ps1"
+
+$StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+$global:KubeletArgs = $FileContent.Trim("KUBELET_KUBEADM_ARGS=`"")
+
+# Recreate network for pods
+Stop-Service docker
+nssm stop HNS
+rm C:\ProgramData\Microsoft\Windows\HNS\HNS.data
+nssm start HNS
+Start-Service docker
+docker network create -d nat host
+
+# May needs to restart network adapter
+Restart-NetAdapter -Name "Ethernet"
+
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:1.3.0`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m"
+
+Invoke-Expression $cmd'
+
+Set-Content -Path $global:StartKubeletScript -Value $StartKubeletFileContent


### PR DESCRIPTION
After previous PR #1  I found out HNS.data wountn't create like expected  after using kubeadm to join a cluster. 

So, I decided recover PrepareNode.ps1 to previous version and create a new PowerShell script, ReplaceKubeletScript.ps1, that will replace the original kubelet start script.

**User will need to run this script after join a cluster.**